### PR TITLE
Refine desktop UI scaling and LIVE indicator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,6 +209,7 @@ export default function App() {
         isAutoMode={isAutoMode}
         lrtOn={lrtOn}
         flightsOn={flightsOn}
+        clock={clock}
         onToggleLrt={toggleLrt}
         onToggleFlights={toggleFlights}
         onToggleRoute={onToggleRoute}

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -217,6 +217,7 @@ export function ControlPanel({ clock }: Props) {
 
   const isPaused = clock.paused
   const speed = clock.speed
+  const isLive = !isPaused && speed === 1 && Math.abs(now.getTime() - Date.now()) < 3000
 
   // ====================================================
   // PHONE: scrubber on top + 44px play/speed-menu/NOW row
@@ -328,7 +329,7 @@ export function ControlPanel({ clock }: Props) {
   // ====================================================
   if (!expanded) {
     return (
-      <div className="absolute bottom-4 left-4 right-4 z-10 mx-auto mm-fade
+      <div className="mm-ui-scale absolute bottom-4 left-4 right-4 z-10 mx-auto mm-fade
                       landscape:bottom-3" style={{ maxWidth: 480 }}>
         <div className="bg-[#0b0b0c]/95 backdrop-blur-md border border-white/10 rounded-sm
                         shadow-2xl overflow-hidden flex items-center gap-0 px-1 py-1">
@@ -356,8 +357,8 @@ export function ControlPanel({ clock }: Props) {
           >
             <DensityBand bins={48} heightPx={14} showPeaks={false} nowFrac={nowFrac} hoverFrac={hoverFrac} small />
           </div>
-          <div className="mm-mono text-[10px] mm-tabular text-amber-200/90 px-2 flex items-center gap-1 shrink-0">
-            <span className="w-1 h-1 rounded-full bg-emerald-400 mm-led-pulse" />
+          <div className={`mm-mono text-[10px] mm-tabular px-2 flex items-center gap-1 shrink-0 ${isLive ? 'text-amber-200/90' : 'text-white/45'}`}>
+            <span className={`w-1 h-1 rounded-full ${isLive ? 'bg-emerald-400 mm-led-pulse' : 'bg-white/25'}`} />
             <span>{hoverLabel ?? nowLabel}</span>
           </div>
           <button
@@ -379,7 +380,7 @@ export function ControlPanel({ clock }: Props) {
   // DESKTOP — expanded: full scrubber with hour axis
   // ====================================================
   return (
-    <div className="absolute bottom-4 left-4 right-4 z-10 mx-auto mm-fade
+    <div className="mm-ui-scale absolute bottom-4 left-4 right-4 z-10 mx-auto mm-fade
                     landscape:bottom-3" style={{ maxWidth: 720 }}>
       <div className="bg-[#0b0b0c]/95 backdrop-blur-md border border-white/10 rounded-sm
                       shadow-2xl overflow-hidden">
@@ -424,9 +425,9 @@ export function ControlPanel({ clock }: Props) {
             <span className="mm-mono text-[9px] tracking-wider">NOW</span>
           </button>
           <div className="flex-1" />
-          <div className="mm-mono mm-tabular text-[9px] text-amber-200/80 pr-2 flex items-center gap-1.5">
-            <span className="w-1 h-1 rounded-full bg-emerald-400 mm-led-pulse" />
-            <span>{hoverLabel ?? `${nowLabel} · NOW`}</span>
+          <div className={`mm-mono mm-tabular text-[9px] pr-2 flex items-center gap-1.5 ${isLive ? 'text-amber-200/80' : 'text-white/40'}`}>
+            <span className={`w-1 h-1 rounded-full ${isLive ? 'bg-emerald-400 mm-led-pulse' : 'bg-white/25'}`} />
+            <span>{hoverLabel ?? (isLive ? `${nowLabel} · NOW` : `${nowLabel} · SIM`)}</span>
           </div>
           <button
             type="button"

--- a/src/components/LineLegend.tsx
+++ b/src/components/LineLegend.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect } from 'react'
-import type { TransitData } from '../types'
+import type { TransitData, SimulationClock } from '../types'
 import { useI18n, localName } from '../i18n'
 import { getRouteGroup, GROUP_ORDER, GROUP_LABEL_KEYS } from '../routeGroups'
 
@@ -13,6 +13,7 @@ interface Props {
   isAutoMode?: boolean
   lrtOn?: Set<string>
   flightsOn?: boolean
+  clock?: SimulationClock
   onToggleLrt?: (id: string) => void
   onToggleFlights?: () => void
   onToggleRoute?: (routeId: string) => void
@@ -31,6 +32,7 @@ export function LineLegend({
   isAutoMode,
   lrtOn,
   flightsOn = true,
+  clock,
   onToggleLrt,
   onToggleFlights,
   onToggleRoute,
@@ -99,6 +101,9 @@ export function LineLegend({
   const totalFlightCount = allTransitData?.flights.length ?? flightCount
 
   const isLrtOn = (id: string) => (lrtOn ? lrtOn.has(id) : true)
+  const isLive = clock
+    ? !clock.paused && clock.speed === 1 && Math.abs(clock.currentTime.getTime() - Date.now()) < 3000
+    : true
 
   return (
     <>
@@ -107,7 +112,7 @@ export function LineLegend({
         <button
           type="button"
           onClick={() => setDesktopOpen(true)}
-          className="absolute top-3 right-3 z-20 hidden sm:flex landscape:hidden
+          className="mm-ui-scale absolute top-3 right-3 z-20 hidden sm:flex landscape:hidden
                      bg-[#0b0b0c]/95 backdrop-blur-md border border-white/10
                      hover:border-amber-300/40 shadow-xl px-3 py-2 items-center gap-3 transition"
         >
@@ -133,22 +138,24 @@ export function LineLegend({
           )}
         </button>
       ) : (
-        <div className="absolute top-3 right-3 z-20 hidden sm:block landscape:hidden
+        <div className="mm-ui-scale absolute top-3 right-3 z-20 hidden sm:block landscape:hidden
                         bg-[#0b0b0c]/95 backdrop-blur-md rounded-sm
                         border border-white/10 overflow-hidden w-[240px] shadow-2xl">
           {/* Header */}
           <div className="px-3 py-1 border-b border-white/10 bg-white/[0.02] flex items-center justify-between">
             <span className="mm-mono text-[9px] tracking-[0.28em] text-amber-300/75">▤ LAYERS</span>
             <div className="flex items-center gap-2">
-              <span className="flex items-center gap-1 mm-mono text-[9px] tracking-[0.2em] text-emerald-300/80">
-                <span className="w-1 h-1 rounded-full bg-emerald-400 mm-led-pulse" />LIVE
+              <span className={`flex items-center gap-1 mm-mono text-[9px] tracking-[0.2em] ${isLive ? 'text-emerald-300/80' : 'text-white/30'}`}>
+                <span className={`w-1 h-1 rounded-full ${isLive ? 'bg-emerald-400 mm-led-pulse' : 'bg-white/25'}`} />
+                {isLive ? 'LIVE' : 'SIM'}
               </span>
               <button
                 type="button"
                 onClick={() => setDesktopOpen(false)}
                 aria-label="collapse layers panel"
-                className="text-white/40 hover:text-white/90 text-[11px] mm-mono w-5 h-5
-                           flex items-center justify-center leading-none transition"
+                className="text-white/55 hover:text-amber-200 hover:bg-white/5 text-[18px] mm-mono
+                           w-6 h-6 flex items-center justify-center leading-none transition
+                           border border-white/10 hover:border-amber-300/40 rounded-sm"
               >
                 ×
               </button>

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -649,7 +649,7 @@ export function MapView({ clock, transitData, allTransitData, onVehicleClick, on
     <>
       <div ref={containerRef} className="w-full h-full" />
       {/* Hamburger + zoom (desktop top-left; phone top-[50px] next to TimeDisplay) */}
-      <div className="absolute z-10 flex items-center gap-1.5
+      <div className="mm-ui-scale absolute z-10 flex items-center gap-1.5
                       top-3 left-3
                       max-sm:top-[50px] max-sm:left-2">
         <button
@@ -690,7 +690,8 @@ export function MapView({ clock, transitData, allTransitData, onVehicleClick, on
 
       {/* Slide-out drawer — CRT / Platform style */}
       <div
-        className={`fixed top-0 left-0 z-40 h-full w-60
+        style={{ zoom: 1.2, height: 'calc(100vh / 1.2)' }}
+        className={`fixed top-0 left-0 z-40 w-60
                     bg-[#0b0b0d] border-r border-amber-300/20
                     shadow-[8px_0_32px_rgba(0,0,0,0.8)]
                     transition-transform duration-200 ease-out

--- a/src/components/TimeDisplay.tsx
+++ b/src/components/TimeDisplay.tsx
@@ -44,6 +44,8 @@ export function TimeDisplay({ clock, vehicleCount }: Props) {
   const s = pad2(time.getSeconds())
   const sched = SCHEDULE_EN[getScheduleType(time)]
   const schedLabel = t[`schedule${getScheduleType(time) === 'mon_thu' ? 'MonThu' : getScheduleType(time) === 'friday' ? 'Friday' : 'SatSun'}` as const]
+  const isLive = !clock.paused && clock.speed === 1 && Math.abs(time.getTime() - Date.now()) < 3000
+  const vehUnit = lang === 'zh' ? '輛' : lang === 'pt' ? 'v' : 'veh'
 
   const handleApply = useCallback((newDate: Date) => {
     clock.setTime(newDate)
@@ -89,7 +91,7 @@ export function TimeDisplay({ clock, vehicleCount }: Props) {
         onClick={() => setOpen(p => !p)}
         title={t.clickToSetTime}
         aria-label={t.clickToSetTime}
-        className="hidden sm:block absolute top-3 left-1/2 -translate-x-1/2 z-30
+        className="mm-ui-scale hidden sm:block absolute top-3 left-1/2 -translate-x-1/2 z-30
                    text-left bg-[#0a0a0b]/95 backdrop-blur-md
                    border border-amber-300/25 rounded-sm overflow-hidden
                    shadow-[0_8px_24px_rgba(0,0,0,0.6)]
@@ -100,8 +102,17 @@ export function TimeDisplay({ clock, vehicleCount }: Props) {
           <span className="mm-mono mm-tabular text-[9px] tracking-[0.15em] text-amber-200/80">
             {yr}·{pad2(mo)}·{pad2(d)} · {dowShort}
           </span>
-          <span className="flex items-center gap-1 mm-mono text-[9px] tracking-[0.2em] text-emerald-300/90">
-            <span className="w-1 h-1 rounded-full bg-emerald-400 mm-led-pulse" />LIVE
+          <span className="flex items-center gap-2 mm-mono text-[9px] tracking-[0.2em]">
+            {clock.speed !== 1 && (
+              <span className="mm-tabular text-amber-300/70">{clock.speed}×</span>
+            )}
+            {vehicleCount !== undefined && vehicleCount > 0 && (
+              <span className="mm-tabular text-white/45">{vehicleCount}{vehUnit}</span>
+            )}
+            <span className={`flex items-center gap-1 ${isLive ? 'text-emerald-300/90' : 'text-white/30'}`}>
+              <span className={`w-1 h-1 rounded-full ${isLive ? 'bg-emerald-400 mm-led-pulse' : 'bg-white/25'}`} />
+              {isLive ? 'LIVE' : 'SIM'}
+            </span>
           </span>
         </div>
         {/* Split-flap */}
@@ -119,7 +130,7 @@ export function TimeDisplay({ clock, vehicleCount }: Props) {
             <span className="mm-mono mm-tabular font-bold text-[40px] leading-none text-amber-200"
                   style={{ letterSpacing: '0.02em' }}>{m}</span>
           </div>
-          <div className="flex flex-col justify-between items-start py-1.5 px-2 bg-[#08080a] min-w-[42px]">
+          <div className="flex-1 flex flex-col justify-between items-start py-1.5 px-2 bg-[#08080a] min-w-[42px]">
             <span className="mm-mono text-[8px] tracking-[0.2em] text-white/35">SEC</span>
             <span className="mm-mono mm-tabular font-bold text-[16px] leading-none text-amber-300/80">{s}</span>
           </div>
@@ -129,12 +140,6 @@ export function TimeDisplay({ clock, vehicleCount }: Props) {
           <span className="mm-mono text-[9px] tracking-[0.18em] text-white/55 uppercase">
             {schedLabel} · {sched} TIMETABLE
           </span>
-          {clock.speed !== 1 && (
-            <span className="mm-mono mm-tabular text-[9px] tracking-wider text-amber-300/70">· {clock.speed}×</span>
-          )}
-          {vehicleCount !== undefined && vehicleCount > 0 && (
-            <span className="mm-mono mm-tabular text-[9px] tracking-wider text-white/40">· {vehicleCount}</span>
-          )}
         </div>
       </button>
 

--- a/src/index.css
+++ b/src/index.css
@@ -41,14 +41,16 @@ html, body, #root {
 * { scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.15) transparent; }
 
 /* Desktop: move MapLibre +/- zoom controls to top-left (below hamburger)
-   so the LAYERS panel at top-right doesn't cover them. */
+   so the LAYERS panel at top-right doesn't cover them. Also scale overlay UI 1.3x. */
 @media (min-width: 640px) and (orientation: portrait), (min-width: 640px) and (min-height: 501px) {
   .maplibregl-ctrl-top-right {
     top: auto;
     right: auto;
     left: 0.75rem;
     top: 3.25rem;
+    zoom: 1.3;
   }
+  .mm-ui-scale { zoom: 1.3; }
 }
 
 @supports (padding: env(safe-area-inset-bottom)) {


### PR DESCRIPTION
- Scale desktop ControlPanel, LAYERS, and TimeDisplay uniformly via mm-ui-scale
- Relocate MapLibre zoom controls to avoid LAYERS collision
- Move speed multiplier and vehicle count into TimeDisplay top strip so the bottom schedule strip no longer stretches the clock (no more dead space right of SEC)
- Append locale-aware unit suffix to vehicle count (輛 / veh / v)
- Switch LIVE → SIM (grey) across TimeDisplay, LAYERS, and speed bar when the clock diverges from real time (paused, sped up, or scrubbed)