### PR TITLE
fix(mobile): normalize AIR/SEA icon size with SVG

### DIFF
--- a/src/components/LineLegend.tsx
+++ b/src/components/LineLegend.tsx
@@ -498,7 +498,10 @@ export function LineLegend({
                            ? 'border-sky-300/25 text-sky-300/80 hover:border-sky-300/50 active:scale-95'
                            : 'border-white/10 text-white/40 hover:border-white/25'}`}
           >
-            <span className="text-[14px] leading-none">✈</span>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M17.8 19.2 16 11l3.5-3.5C21 6 21.5 4 21 3c-1-.5-3 0-4.5 1.5L13 8 4.8 6.2c-.5-.1-.9.1-1.1.5l-.3.5c-.2.5-.1 1 .3 1.3L9 12l-2 3H4l-1 1 3 2 2 3 1-1v-3l3-2 3.5 5.3c.3.4.8.5 1.3.3l.5-.2c.4-.3.6-.7.5-1.2z" />
+            </svg>
           </button>
         )}
 
@@ -515,7 +518,12 @@ export function LineLegend({
                            ? 'border-red-400/25 text-red-300/80 hover:border-red-400/50 active:scale-95'
                            : 'border-white/10 text-white/40 hover:border-white/25'}`}
           >
-            <span className="text-[14px] leading-none">{'\u2693\uFE0E'}</span>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <circle cx="12" cy="5" r="3" />
+              <line x1="12" y1="22" x2="12" y2="8" />
+              <path d="M5 12H2a10 10 0 0 0 20 0h-3" />
+            </svg>
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Mobile right-side icon stack rendered the anchor (⚓ U+2693) and plane (✈ U+2708) as text glyphs at `text-[14px]`. Because U+2693 has a narrower intrinsic glyph than U+2708, the anchor looked visibly smaller than the LRT/BUS SVG icons next to it.
- Replaced both with 16×16 stroke SVGs that mirror the existing LRT/BUS icon style in `LineLegend.tsx`, removing the dependency on system font emoji presentation and giving consistent visual weight across iOS/Android/web.
- Desktop layers panel and modal headers still use the Unicode glyph and are unchanged.

## Test plan
- [x] `npm run build` (tsc + vite) passes
- [ ] Visual check on mobile Safari / Chrome: AIR and SEA buttons match LRT/BUS sizing
- [ ] Confirm color states (active / inactive / hover) still apply via `currentColor`

https://claude.ai/code/session_014V3Pjo8pida61c22XyUQPD

---
_Generated by [Claude Code](https://claude.ai/code/session_014V3Pjo8pida61c22XyUQPD)_