### PR TITLE
chore(ci): bump GitHub Actions to Node 24 runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -35,11 +35,11 @@ jobs:
   data:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # validate_output.py is pure stdlib, so a bare Python is enough — no need
       # to install the scraper dependencies.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,12 +23,12 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Empty for push events → falls back to the exact pushed sha.
           ref: ${{ inputs.ref || github.sha }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -18,16 +18,16 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -35,7 +35,7 @@ jobs:
 
       - name: Compute image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/mini-macau-rt
           tags: |
@@ -45,7 +45,7 @@ jobs:
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/service-status.yml
+++ b/.github/workflows/service-status.yml
@@ -14,9 +14,9 @@ jobs:
       # Consumed by the deploy job below.
       changed: ${{ steps.diff.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
         with:
           version: latest
 

--- a/.github/workflows/update-ferry-schedules.yml
+++ b/.github/workflows/update-ferry-schedules.yml
@@ -14,9 +14,9 @@ jobs:
       # Consumed by the deploy job below.
       changed: ${{ steps.diff.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
         with:
           version: latest
 

--- a/.github/workflows/update-flights-timetable.yml
+++ b/.github/workflows/update-flights-timetable.yml
@@ -18,9 +18,9 @@ jobs:
       # Consumed by the deploy job below.
       changed: ${{ steps.diff.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
         with:
           version: latest
 

--- a/.github/workflows/update-flights.yml
+++ b/.github/workflows/update-flights.yml
@@ -18,9 +18,9 @@ jobs:
       # Consumed by the deploy job below.
       changed: ${{ steps.diff.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
         with:
           version: latest
 


### PR DESCRIPTION
## Why

GitHub force-migrates Node 20 actions onto Node 24 on **2026-06-16**, and removes the Node 20 runtime from runners on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Recent Actions runs were emitting the deprecation warning for several actions still on Node 20.

This bumps every JavaScript action to a major whose `action.yml` declares `runs.using: node24`.

## Changes

| Action | From | To | Runtime |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | node24 |
| `actions/setup-node` | v4 | v5 | node24 |
| `actions/setup-python` | v5 | v6 | node24 |
| `astral-sh/setup-uv` | v4 | v7 | node24 |
| `docker/setup-qemu-action` | v3 | v4 | node24 |
| `docker/setup-buildx-action` | v3 | v4 | node24 |
| `docker/login-action` | v3 | v4 | node24 |
| `docker/metadata-action` | v5 | v6 | node24 |
| `docker/build-push-action` | v6 | v7 | node24 |

`setup-uv` is pinned to `v7` (not `v8`): v8 has no floating major tag yet (only `v8.x.y`), and `v7` is already node24, keeping the repo's floating-major convention.

## Verification

- Each target's `runs.using` confirmed `node24` from its `action.yml` at the pinned tag.
- All 7 workflow YAML files parse cleanly.
- Diff is a pure version-token swap (20 insertions / 20 deletions, no structural change).
- CI on this PR exercises `actions/checkout@v5`, `actions/setup-node@v5`, and `actions/setup-python@v6` directly — the run should be free of the Node 20 deprecation warning.
- `astral-sh/setup-uv@v7` and the `docker/*` actions aren't on the PR's CI path; they're verified via `action.yml` and will exercise on the next scheduled data run / Docker release.

Usage is drop-in: `setup-uv` uses only `version: latest`; `setup-node`/`setup-python` pin `node-version`/`python-version` explicitly; the docker actions use standard inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
